### PR TITLE
Use correct syntax in lib/reacto/trackable.rb

### DIFF
--- a/lib/reacto/trackable.rb
+++ b/lib/reacto/trackable.rb
@@ -620,7 +620,7 @@ module Reacto
       slice(pattern, type: :before, &block)
     end
 
-    def slice(pattern = NO_ACTION, type:, &block)
+    def slice(pattern = NO_ACTION, type: type, &block)
       predicate =
         if pattern != NO_VALUE
           -> (val) { pattern === val }


### PR DESCRIPTION
- looks like a typo?
- rubocop failed to parse this file using Ruby-2.0 parser
