### PR TITLE
Pass Lint/UselessAssignment

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,14 +51,6 @@ Lint/UnusedMethodArgument:
     - 'lib/reacto/subscriptions.rb'
     - 'lib/reacto/subscriptions/subscription.rb'
 
-# Offense count: 5
-Lint/UselessAssignment:
-  Exclude:
-    - 'spec/reacto/trackable/class_level/enumerable_spec.rb'
-    - 'spec/reacto/trackable/class_level/interval_spec.rb'
-    - 'spec/reacto/trackable/class_level/later_spec.rb'
-    - 'spec/reacto/trackable/class_level/value_spec.rb'
-
 # Offense count: 15
 Metrics/AbcSize:
   Max: 32

--- a/spec/reacto/trackable/class_level/enumerable_spec.rb
+++ b/spec/reacto/trackable/class_level/enumerable_spec.rb
@@ -4,7 +4,7 @@ context Reacto::Trackable do
   context '.enumerable' do
     it 'emits the whole enumerable one-by-one and then closes' do
       trackable = described_class.enumerable([1, 3, 5, 6, 7, 8])
-      subscription = attach_test_trackers(trackable)
+      attach_test_trackers(trackable)
 
       expect(test_data).to be == [1, 3, 5, 6, 7, 8, '|']
     end
@@ -31,7 +31,7 @@ context Reacto::Trackable do
 
       enumerable = PositiveArray.new(2, 3, -4, 3, 6)
       trackable = described_class.enumerable(enumerable)
-      subscription = attach_test_trackers(trackable)
+      attach_test_trackers(trackable)
 
       expect(test_data).to be == [2, 3, enumerable.error]
     end

--- a/spec/reacto/trackable/class_level/interval_spec.rb
+++ b/spec/reacto/trackable/class_level/interval_spec.rb
@@ -34,7 +34,7 @@ context Reacto::Trackable do
       trackable = described_class.interval(
         0.1, (1..5).each, executor: Reacto::Executors.immediate
       )
-      subscription = attach_test_trackers(trackable)
+      attach_test_trackers(trackable)
 
       expect(test_data).to eq((1..5).to_a + ['|'])
     end

--- a/spec/reacto/trackable/class_level/later_spec.rb
+++ b/spec/reacto/trackable/class_level/later_spec.rb
@@ -16,7 +16,7 @@ context Reacto::Trackable do
       trackable = described_class.later(
         0.2, 5, executor: Reacto::Executors.immediate
       )
-      subscription = attach_test_trackers(trackable)
+      attach_test_trackers(trackable)
       expect(test_data).to be == [5, '|']
     end
   end

--- a/spec/reacto/trackable/class_level/value_spec.rb
+++ b/spec/reacto/trackable/class_level/value_spec.rb
@@ -4,7 +4,7 @@ context Reacto::Trackable do
   context '.value' do
     it 'emits only the passed value and then closes' do
       trackable = described_class.value(5)
-      subscription = attach_test_trackers(trackable)
+      attach_test_trackers(trackable)
 
       expect(test_data).to be == [5, '|']
     end


### PR DESCRIPTION
- Compared to other specs it's clear why these assignments were left here, as the specs all start the same way, but rubocop's argument is to remove anything unused.
